### PR TITLE
feat: update repository references and enhance documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          generate_attestations: true
+          go_version_file: go.mod

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "bulkpr"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ BulkPR is a tool designed to automate the creation of pull requests across multi
 
 ## Features
 
-- Bulk createtion of pull requests across multiple repositories
-- Customizable PR titles, descritons, and branch names
+- Bulk creation of pull requests across multiple repositories
+- Customizable PR titles, descriptions, and branch names
 - Easy configuration using YAML files
 
 ## Prerequisites
@@ -15,7 +15,17 @@ BulkPR is a tool designed to automate the creation of pull requests across multi
 
 ## Installation
 
-To install BulkPR, download the latest executable from the [releases](https://github.com/l-melon/bulkpr/releases) page.
+### As a Standalone Executable
+
+To install BulkPR, download the latest executable from the [releases](https://github.com/l-lumin/gh-bulkpr/releases) page.
+
+### As a Github CLI Extension
+
+If you already have Github CLI installed, you can install BulkPR as a Github CLI extension for easy integration:
+
+```sh
+gh extension install l-lumin/gh-bulkpr
+```
 
 ## Configuration
 
@@ -28,10 +38,12 @@ repos:
     head: develop
     title: "Test PR"
     body: "Test"
-    repo: "l-melon/bulkpr"
+    repo: "l-lumin/gh-bulkpr"
 ```
 
 ## Usage
+
+### Using the Standalone Executable
 
 Once the configuration file is set up, run the tool using the following command:
 
@@ -39,6 +51,18 @@ Once the configuration file is set up, run the tool using the following command:
 bulkpr config.yaml
 ```
 
+### Using the Github CLI Extension
+
+```sh
+gh bulkpr config.yaml
+```
+
+## Command Flags
+
+- `--help`: Display help for the command
+- `--version`: Show the version of the `gh-bulkpr` extension
+
 ## Future Plans
+
 - Support for multiple config files
 - Integration with CI/CD tools

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/l-melon/bulkpr
+module github.com/l-lumin/bulkpr
 
 go 1.23.2
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -91,16 +92,34 @@ func createPullRequest(config *Config) error {
 	return nil
 }
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatal("Usage: program <config-file>")
-	}
-	configFile := os.Args[1]
+	// Define flags
+	help := flag.Bool("help", false, "Show help")
+	version := flag.Bool("version", false, "Show version")
 
+	// Parse flags
+	flag.Parse()
+
+	if *help {
+		fmt.Println("Usage: gh bulkpr <config-file>")
+		fmt.Println("Create pull requests in multiple repositories using a single command")
+	}
+
+	if *version {
+		fmt.Println("gh-bulkpr v0.1.0")
+	}
+
+	if len(flag.Args()) < 1 {
+		log.Fatal("Usage: bulkpr <config-file>")
+	}
+	configFile := flag.Args()[0]
+
+	// Read the configuration file
 	config, err := readYAMLConfig(configFile)
 	if err != nil {
 		log.Fatalf("Error reading config file: %v", err)
 	}
 
+	// Create pull requests
 	err = createPullRequest(config)
 	if err != nil {
 		log.Fatalf("Error creating pull requests: %v", err)

--- a/settings.yaml
+++ b/settings.yaml
@@ -4,4 +4,4 @@ repos:
     head: develop
     title: "Test PR"
     body: "Test"
-    repo: "l-melon/bulkpr"
+    repo: "l-lumin/gh-bulkpr"


### PR DESCRIPTION
Change the repository reference from "l-melon/bulkpr" to 
"l-lumin/gh-bulkpr" in configuration files. Add usage instructions 
for both standalone executable and GitHub CLI extension in the 
README. Introduce command flags for help and version in the main 
program. Update the module name in go.mod and add a GitHub Actions 
workflow for releases. These changes improve clarity, usability, 
and facilitate easier integration with GitHub CLI.